### PR TITLE
Make DenomUnit struct public

### DIFF
--- a/packages/bindings/src/lib.rs
+++ b/packages/bindings/src/lib.rs
@@ -9,7 +9,7 @@ pub use query::{
     AdminResponse, DenomsByCreatorResponse, FullDenomResponse, MetadataResponse, ParamsResponse,
     TokenFactoryQuery, TokenQuery,
 };
-pub use types::{Metadata, Params};
+pub use types::{DenomUnit, Metadata, Params};
 
 // This is a signal, such that any contract that imports these helpers will only run on
 // blockchains that support token_factory feature


### PR DESCRIPTION
This makes the `DenomUnit` struct public so that external contracts can build the `Metadata` struct and create new denoms/update metadata. I'm a bit new to Rust, so I may be missing something.

Also, can we get this package published on crates.io so it can be imported without a git dependency?