### PR TITLE
Make DenomUnit struct members public

### DIFF
--- a/packages/bindings/src/types.rs
+++ b/packages/bindings/src/types.rs
@@ -28,9 +28,9 @@ pub struct DenomUnit {
     /// 1 denom = 1^exponent base_denom
     /// (e.g. with a base_denom of uatom, one can create a DenomUnit of 'atom' with
     /// exponent = 6, thus: 1 atom = 10^6 uatom).
-    exponent: u32,
+    pub exponent: u32,
     /// aliases is a list of string aliases for the given denom
-    aliases: Vec<String>,
+    pub aliases: Vec<String>,
 }
 
 /// This maps to osmosis.tokenfactory.v1beta1.Params protobuf struct


### PR DESCRIPTION
This makes the `DenomUnit` struct's members public so it can be created outside of the package. This is necessary for using the `TokenMsg::SetMetadata` message.